### PR TITLE
Update rust-analyzer VSCode extension name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,11 +14,11 @@
     },
     "rust-analyzer.checkOnSave.command": "clippy",
     "[rust]": {
-      "editor.defaultFormatter": "matklad.rust-analyzer"
+      "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },
   },
   "extensions": [
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "tamasfe.even-better-toml",
     "vadimcn.vscode-lldb",
     "serayuzgur.crates",

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       source /home/gitpod/.cargo/env
 vscode:
   extensions:
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer
     - tamasfe.even-better-toml
     - vadimcn.vscode-lldb
     - anwar.resourcemonitor


### PR DESCRIPTION
[rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) has a new name.